### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!--
+By submitting this pull request, you agree to:
+- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
+- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
+- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
+-->
+## Description
+
+-
+
+<!--
+Please add in issue numbers this pull request will close, if applicable
+Examples: Fixes #4321 or Closes #1234
+
+Ensure you are using a supported keyword to properly link an issue:
+https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
+-->
+## Closes


### PR DESCRIPTION
## Description

Adds `.github/PULL_REQUEST_TEMPLATE.md` so new PRs are pre-populated with a consistent structure: Code of Conduct / contribution links, a **Description** section, and a **Closes** section for issue linking.

Content adopted verbatim from litestar-org/project-template#16 (the copier-based PR), matching the maintainers' latest intent. Note this template is intentionally minimal — the older checklist (coverage/docs/pre-commit/tests) was dropped in #16, and this PR preserves that decision.

## Closes

- Closes #25

## Summary by Sourcery

Documentation:
- Introduce a minimal `.github/PULL_REQUEST_TEMPLATE.md` documenting required description and issue-closing sections for new pull requests.