### PR TITLE
docs: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Code owner settings for `project-template`
+# @maintainers should be assigned to all reviews.
+# Most specific assignment takes precedence though, so if you add a more specific thing than the `*` glob, you must also add @maintainers
+# For more info about code owners see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-example
+
+# Global Assignment
+*      @litestar-org/maintainers @litestar-org/members
+
+# Documentation
+docs/* @litestar-org/maintainers @JacobCoffee @provinzkraut


### PR DESCRIPTION
## Description

Adds `.github/CODEOWNERS` so reviews are auto-requested from maintainers:

- Global: `* @litestar-org/maintainers @litestar-org/members`
- Docs: `docs/* @litestar-org/maintainers @JacobCoffee @provinzkraut`

Content adopted from litestar-org/project-template#16 (header adjusted from `litestar` to `project-template`). Both referenced teams (`maintainers`, `members`) were confirmed to exist in the org.

> **Note for reviewers:** auto-review-requests only fire if the referenced teams/users have **write access** to this repo — an org/repo settings detail outside this PR.

## Closes

- Closes #26

## Summary by Sourcery

Chores:
- Introduce .github/CODEOWNERS file defining global and docs-specific code ownership.