### PR TITLE
docs: enrich issue template chooser with contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,1 +1,11 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Litestar Documentation
+    url: https://docs.litestar.dev/
+    about: Official Litestar documentation - please check here before opening an issue.
+  - name: Litestar Website
+    url: https://litestar.dev/
+    about: Main Litestar website - for details about Litestar's projects.
+  - name: Discord
+    url: https://discord.gg/litestar
+    about: Join our Discord community to chat or get in touch with the maintainers.


### PR DESCRIPTION
## Description

Adds a `contact_links` block to `.github/ISSUE_TEMPLATE/config.yaml` so the issue chooser points users to Documentation, the Website, and Discord before they open an issue.

Adapted from litestar-org/project-template#16, with two corrections:

- **Fixed the config key.** #16 used `blank_lines_enabled: true`, which is **not a valid** GitHub key ([only `blank_issues_enabled` is recognized](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser)) — it was silently ignored and would have defaulted blank issues back to *enabled*. This PR keeps the correct `blank_issues_enabled: false`, preserving current behavior.
- **Modern Discord invite** (`discord.gg/litestar`).

Validated as parseable YAML with the expected keys.

## Closes

- Closes #30

## Summary by Sourcery

Documentation:
- Update issue template configuration to surface documentation, website, and Discord contact options in the issue chooser.