### PR TITLE
ci: adopt zizmor and harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Wait a week before proposing a newly-published version, mirroring the uv
+    # `exclude-newer` policy. Reduces exposure to compromised fresh releases.
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,13 +6,19 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
@@ -21,7 +27,7 @@ jobs:
 
       - name: Load cached Pre-Commit Dependencies
         id: cached-pre-commit-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: ~/.cache/pre-commit/
           key: pre-commit-|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
@@ -33,6 +39,8 @@ jobs:
         run: pre-commit run --show-diff-on-failure --color=always --all-files
 
   test:
+    permissions:
+      contents: read
     strategy:
       fail-fast: true
       matrix:
@@ -43,6 +51,8 @@ jobs:
       coverage: ${{ matrix.python-version == '3.11' }}
 
   test-platform-compat:
+    permissions:
+      contents: read
     if: github.event_name == 'push'
     strategy:
       fail-fast: true
@@ -57,22 +67,27 @@ jobs:
     needs:
       - test
       - validate
+    permissions:
+      contents: read
     if: github.event.pull_request.head.repo.fork == false && github.repository_owner == 'litestar-org'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: coverage-xml
       - name: Fix coverage file for sonarcloud
         run: sed -i "s/home\/runner\/work\/litestar\/litestar/github\/workspace/g" coverage.xml
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+      - name: SonarQube Cloud Scan
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
 
   codeql:
     needs:
@@ -80,14 +95,17 @@ jobs:
       - validate
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - name: Initialize CodeQL Without Dependencies
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
         with:
           setup-python-dependencies: false
           languages: python
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,19 +4,23 @@ on:
   schedule:
     - cron: "0 4 * * *"
 
+permissions: {}
+
 jobs:
   codeql:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: "main"
+          persist-credentials: false
 
       - name: Initialize CodeQL With Dependencies
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,19 +4,23 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   docs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: "3.11"
-          enable-cache: true
+          enable-cache: false
 
       - name: Install dependencies
         run: uv sync --all-groups
@@ -28,6 +32,6 @@ jobs:
         run: uv run python tools/build_docs.py docs-build
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4
         with:
           folder: docs-build

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   publish-release:
     runs-on: ubuntu-latest
@@ -11,16 +13,18 @@ jobs:
       id-token: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: "3.11"
-          enable-cache: true
+          enable-cache: false
 
       - name: Build package distributions
         run: uv build
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,19 +15,25 @@ on:
         type: string
         default: "ubuntu-latest"
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ${{ inputs.os }}
     timeout-minutes: 10
+    permissions:
+      contents: read
     defaults:
       run:
         shell: bash
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: ${{ inputs.python-version }}
           enable-cache: true
@@ -43,7 +49,7 @@ jobs:
         if: inputs.coverage
         run: uv run pytest docs/examples tests --cov=project_template --cov-report=xml
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: inputs.coverage
         with:
           name: coverage-xml

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF results to the Security tab
+      contents: read # only needed for private or internal repos
+      actions: read # only needed for private or internal repos
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,10 @@ repos:
     rev: 0.11.31
     hooks:
       - id: uv-lock
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.28.0
+    hooks:
+      - id: zizmor
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: "v0.0.290"
     hooks:


### PR DESCRIPTION
## Description

Adopts [zizmor](https://docs.zizmor.sh/) to statically analyze our GitHub Actions, wired in as a **pre-commit hook** (`zizmorcore/zizmor-pre-commit`). Because the existing `validate` CI job already runs `pre-commit run --all-files`, this makes zizmor a **required CI check with no new workflow and no extra action to pin**.

Per maintainer direction, this uses the **strict** policy (SHA-pin everything) and resolves **every** finding to zero.

### Findings resolved (23 high + 13 medium → 0)

| Audit | Fix |
|---|---|
| `unpinned-uses` (21) | All actions pinned to full commit SHAs; version kept as a trailing `# vX` comment |
| `artipacked` (7) | `persist-credentials: false` on every `actions/checkout` |
| `excessive-permissions` (5) | Top-level `permissions: {}` on every workflow + least-privilege per-job grants |
| `cache-poisoning` (2) | `enable-cache: false` on the release-triggered `docs`/`publish` workflows |
| `archived-uses` (1) | Archived `sonarsource/sonarcloud-github-action@master` replaced |
| `dependabot-cooldown` (1) | 7-day dependabot cooldown |

### Notable changes reviewers should sanity-check

- **Sonar migration.** `sonarsource/sonarcloud-github-action@master` (archived) → **`SonarSource/sonarqube-scan-action`**, pinned to **v6**. v4–v5 are vulnerable to argument injection ([GHSA-5xq9-5g24-4g6f](https://github.com/advisories/GHSA-5xq9-5g24-4g6f)); v6.0.0 is the first patched release. Added `SONAR_HOST_URL: https://sonarcloud.io` as required by the new action. **Worth a live check that the Sonar scan still reports.**
- **CodeQL bump.** `github/codeql-action` **v2 → v3** — v2 is retired, so pinning a v2 SHA would be a dead pin.
- **Dependabot cooldown** mirrors the uv `exclude-newer = "1 week"` policy from #19.

### Verification

- `zizmor .github/workflows/` → **No findings to report** (16 suppressed by default persona).
- `pre-commit run zizmor --all-files` → **Passed** (also audits `.github/dependabot.yaml`).
- All workflow YAML validated.

> Note: SHA pins want a bot (Dependabot/Renovate, see #21) to stay fresh — Dependabot's `github-actions` updater already covers them.

## Closes

- Closes #22

## Summary by Sourcery

Harden GitHub Actions workflows and CI configuration, including adopting zizmor in pre-commit and tightening security posture across workflows.

Enhancements:
- Adopt zizmor as a pre-commit hook so workflow security checks run as part of the existing validate job.
- Pin all GitHub Actions used in CI, docs, publish, test, and CodeQL workflows to specific commit SHAs.
- Restrict default and job-level GitHub Actions permissions to least-privilege, adding explicit contents read/write and security-events scopes where required.
- Disable uv action caching in release-triggered docs and publish workflows to reduce cache-related risks.
- Replace the deprecated SonarCloud GitHub Action with the maintained SonarQube scan action configured for sonarcloud.io.
- Upgrade CodeQL workflows from v2 to v3 while retaining existing analysis behavior.
- Configure Dependabot with a 7-day cooldown for GitHub Actions updates to align with the project’s release hygiene policy.

CI:
- Strengthen CI workflows by enforcing pinned actions, strict permissions, and secure Sonar and CodeQL integrations.

Tests:
- Ensure coverage artifact upload and related test workflow steps use pinned actions with constrained permissions.

Chores:
- Update pre-commit configuration to include zizmor and keep CI security tooling consistent across the project.

---

### Two layers of zizmor

Following the [zizmor-action](https://github.com/zizmorcore/zizmor-action) usage (modeled on [Starlette's workflow](https://github.com/Kludex/starlette/blob/main/.github/workflows/zizmor.yml)):

| Layer | How | Behavior |
|---|---|---|
| **Blocking gate** | `zizmor` pre-commit hook (runs in the `validate` job + locally) | Hard-fails on any finding; also gives local pre-commit feedback |
| **Security dashboard** | `.github/workflows/zizmor.yml` → `zizmorcore/zizmor-action` (SHA-pinned `v0.6.0`) | Uploads SARIF to the **Security tab** via GitHub Advanced Security (public repo) for stateful, incremental triage; non-blocking by design |

The new workflow is itself SHA-pinned and least-privilege, so it passes the zizmor audit it runs.