### PR TITLE
ci: add PR title linting (Conventional Commits)

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,24 @@
+name: Lint PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions: {}
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      # Title validation needs no write token, so plain pull_request (rather
+      # than pull_request_target) is used - safer, and avoids running with a
+      # privileged token on fork PRs.
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Adds `.github/workflows/pr-title.yml` — validates PR titles as [Conventional Commits](https://www.conventionalcommits.org/) via `amannn/action-semantic-pull-request`, matching the repo's PR-title convention and enabling downstream label/changelog automation.

Adapted from litestar-org/project-template#16, with two deliberate changes:

- **`pull_request` instead of `pull_request_target`.** Title validation needs no write token, so the privileged trigger #16 used is unnecessary — plain `pull_request` is strictly safer and avoids zizmor's `dangerous-triggers` finding entirely (no suppression comment needed).
- **Hardened for the zizmor gate (#22/#39):** SHA-pinned action (`@48f2562 # v6.1.1`, bumped from #16's v5), top-level `permissions: {}`, least-privilege `pull-requests: read`.

Verified: `zizmor` → **No findings to report**.

## Closes

- Closes #41

## Summary by Sourcery

CI:
- Introduce a GitHub Actions workflow that lints PR titles using semantic pull request rules on pull_request events.