### PR TITLE
ci: auto-close linked issues on PR merge

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -1,0 +1,59 @@
+name: PR merged
+
+on:
+  # pull_request_target is required so GITHUB_TOKEN can close/comment on issues
+  # for PRs originating from forks. Safe here: no PR head code is checked out or
+  # executed - the job only makes API calls via github-script.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    types:
+      - closed
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  close_and_notify:
+    name: Close linked issues and notify
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const prNumber = context.payload.number
+            const commentBody = `<!--closing-comment-->\nThis issue has been closed in #${prNumber}. The change will be included in the next release.`
+
+            const query = `query($number: Int!, $owner: String!, $name: String!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                  id
+                  closingIssuesReferences(first: 10) { edges { node { number } } }
+                }
+              }
+            }`
+            const res = await github.graphql(query, { number: prNumber, owner: context.repo.owner, name: context.repo.repo })
+            const linkedIssues = res.repository.pullRequest.closingIssuesReferences.edges.map(
+              edge => edge.node.number
+            )
+
+            for (const issueNumber of linkedIssues) {
+              const update = await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                state: "closed",
+                state_reason: "completed"
+              })
+              if (update.status === 200) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body: commentBody
+                })
+              }
+            }


### PR DESCRIPTION
## Description

Adds `.github/workflows/pr-merged.yml`: when a PR targeting `main` is merged, it closes the issues that PR references (via the `closingIssuesReferences` GraphQL API) and posts a comment noting the change ships in the next release.

Adapted from litestar-org/project-template#16:

- **Dropped the `develop` branch** (this repo only has `main`) and the minor/patch wording that depended on it — comment now just says "the next release".
- **Hardened for the zizmor gate (#22/#39):** SHA-pinned `github-script` (`@3a2844b # v9.0.0`), top-level `permissions: {}`, least-privilege `issues: write` + `pull-requests: read`.

### Why `pull_request_target`

Closing/commenting on issues needs a write token, which fork PRs don't get under plain `pull_request`. `pull_request_target` provides it. This is safe because the job **only makes API calls via github-script** — it never checks out or executes PR head code. zizmor's `dangerous-triggers` finding is suppressed inline with that justification.

> GitHub already auto-closes issues from `Closes #N` keywords; the added value here is the **release-note comment** plus closing issues linked via the API.

Verified: `zizmor` → **No findings** (1 justified ignore).

## Closes

- Closes #42

## Summary by Sourcery

CI:
- Introduce a pull_request_target GitHub Actions workflow that uses least-privilege permissions to close linked issues and comment when a PR to main is merged.