### PR TITLE
ci: add PR auto-labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,68 @@
+version: v1
+
+labels:
+  # -- type (from the Conventional Commit PR title) ---------------------------
+  - label: "type/feat"
+    sync: true
+    matcher:
+      title: '^feat(\([^)]+\))?!?:'
+
+  - label: "type/fix"
+    sync: true
+    matcher:
+      title: '^fix(\([^)]+\))?!?:'
+
+  - label: "type/docs"
+    sync: true
+    matcher:
+      title: '^docs(\([^)]+\))?:'
+
+  - label: "type/refactor"
+    sync: true
+    matcher:
+      title: '^refactor(\([^)]+\))?:'
+
+  - label: "type/test"
+    sync: true
+    matcher:
+      title: '^test(\([^)]+\))?:'
+
+  - label: "type/ci"
+    sync: true
+    matcher:
+      title: '^(ci|build)(\([^)]+\))?:'
+
+  - label: "type/chore"
+    sync: true
+    matcher:
+      title: '^chore(\([^)]+\))?:'
+
+  - label: "Breaking"
+    sync: true
+    matcher:
+      title: '^\w+(\([^)]+\))?!:'
+
+  # -- area (from changed paths) ----------------------------------------------
+  - label: "area/docs"
+    sync: true
+    matcher:
+      files:
+        any: ["docs/**", "**/*.rst", "**/*.md"]
+
+  - label: "area/src"
+    sync: true
+    matcher:
+      files:
+        any: ["src/**"]
+
+  - label: "area/tests"
+    sync: true
+    matcher:
+      files:
+        any: ["tests/**", "docs/examples/**"]
+
+  - label: "area/ci"
+    sync: true
+    matcher:
+      files:
+        any: [".github/**"]

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,53 @@
+name: Pull Request Labeler
+
+on:
+  # pull_request_target is required so GITHUB_TOKEN can add labels to PRs
+  # originating from forks. Safe here: no PR head code is checked out or
+  # executed - the jobs only use the labeler action and API calls, and the
+  # labeler config is read from the base repository.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions: {}
+
+jobs:
+  apply-labels:
+    name: Apply labels from title and paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: fuxingloh/multi-labeler@b15a54460c38f54043fa75f7b08a0e2aa5b94b5b # v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  distinguish-pr-origin:
+    name: Label internal vs external contributions
+    needs: apply-labels
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            // author_association avoids a hard-coded maintainer list: OWNER,
+            // MEMBER, and COLLABORATOR are treated as internal.
+            const association = context.payload.pull_request.author_association
+            const internal = ["OWNER", "MEMBER", "COLLABORATOR"].includes(association)
+            const labels = internal
+              ? ["pr/internal"]
+              : ["pr/external", "triage required"]
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels
+            })


### PR DESCRIPTION
## Description

Adds automatic PR labeling via `fuxingloh/multi-labeler` plus a **template-appropriate** `.github/labeler.yml`. Adapted from litestar-org/project-template#16, which shipped a 306-line config tailored to the litestar monorepo.

### `.github/labeler.yml`
- **`type/*`** from the Conventional Commit PR title: `feat`, `fix`, `docs`, `refactor`, `test`, `ci`/`build`, `chore`, plus **`Breaking`** from a `!` bang. (Pairs with #41's title linting.)
- **`area/*`** from changed paths: `docs`, `src`, `tests`, `ci` — generic to the template's `src/`-layout structure.

### `distinguish-pr-origin` job
Labels each PR `pr/internal` or `pr/external` + `triage required`. Uses the PR's **`author_association`** (`OWNER`/`MEMBER`/`COLLABORATOR` = internal) instead of #16's **hard-coded maintainer list** — so it needs no maintenance and works for any repo using this template.

### Labels
The referenced labels have been created in the repo (`type/*`, `area/*`, `Breaking`, `pr/internal`, `pr/external`); `triage required` already existed. Colors/descriptions are easy to tune.

### Hardening (zizmor gate, #22/#39)
- SHA-pinned `multi-labeler@b15a544 # v4` and `github-script@3a2844b # v9.0.0`.
- `permissions: {}` top-level; jobs get only `contents: read`+`pull-requests: write` / `issues: write`+`pull-requests: write`.
- **`pull_request_target`** is required to label fork PRs; safe (no PR code checked out) and justified-suppressed for zizmor's `dangerous-triggers`.

Verified: `zizmor` → **No findings** (1 justified ignore).

## Closes

- Closes #43

## Summary by Sourcery

Introduce automated pull request labeling based on conventional commit titles, changed paths, and PR origin (internal vs external).

Build:
- Add a repository-wide labeler configuration mapping conventional commit-style PR titles and file path changes to type/* and area/* labels.

CI:
- Add a PR labeler workflow that applies type/area labels using multi-labeler on pull_request_target events.
- Label PRs as internal or external based on author_association, adding triage required for external contributions.